### PR TITLE
Added id_token and refresh_token to RefreshTokenResponse type

### DIFF
--- a/src/AppleSignIn.ts
+++ b/src/AppleSignIn.ts
@@ -65,7 +65,7 @@ export interface AccessTokenResponse {
   token_type: string;
 }
 
-export type RefreshTokenResponse = Pick<AccessTokenResponse, "access_token" | "expires_in" | "token_type">;
+export type RefreshTokenResponse = Pick<AccessTokenResponse, "access_token" | "expires_in" | "token_type" | "id_token" | "refresh_token" >;
 
 /**
  * https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple#3383773


### PR DESCRIPTION
RefreshTokenResponse type only picks access_token, expires_in, and token_type from Apple's response. The response also includes id_token and (possibly new) refresh_token. When refreshing a token these fiels are sometimes necessary.